### PR TITLE
[fix] remove references to obsolete param

### DIFF
--- a/server-mode/performance-considerations.md
+++ b/server-mode/performance-considerations.md
@@ -52,14 +52,13 @@ JAVA_OPTS="-Xms10g -Xmx50g" datashare --mode CLI --stage INDEX
 If the document language is known, explicitly setting it can save processing time.
 
 * **Use `--language`** for general language setting (e.g., `FRENCH`, `ENGLISH`).
-* **Use `--ocrLanguage`** for OCR tasks to specify the Tesseract model (e.g., `fra`, `eng`).
 
 _Example:_
 
 ```bash
-datashare --mode CLI --stage INDEX --language FRENCH --ocrLanguage fra
-datashare --mode CLI --stage INDEX --language CHINESE --ocrLanguage chi_sim
-datashare --mode CLI --stage INDEX --language GREEK --ocrLanguage ell
+datashare --mode CLI --stage INDEX --language FRENCH
+datashare --mode CLI --stage INDEX --language CHINESE
+datashare --mode CLI --stage INDEX --language GREEK
 ```
 
 ### **Manage OCR Tasks Wisely**


### PR DESCRIPTION
I've used the 'ocrLanguage' param but got an error, hence I figured the documentation may be referring to a now deprecated parameter.

If I'm mistaken, please disregard my PR.

I haven't looked deeply into the code, but maybe we can erase altogether the "**Use `--language`** for general language setting (e.g., `FRENCH`, `ENGLISH`)." documentation about performances, if that's now irrelevant ?