### PR TITLE
Add --oauthScope argument to OAuth examples

### DIFF
--- a/server-mode/authentication-providers/oauth2.md
+++ b/server-mode/authentication-providers/oauth2.md
@@ -17,7 +17,8 @@ docker run -ti ICIJ/datashare:version --mode SERVER \
     --oauthAuthorizeUrl https://my.oauth-server.org/oauth/authorize \
     --oauthTokenUrl https://my.oauth-server.org/oauth/token \
     --oauthApiUrl https://my.oauth-server.org/api/v1/me.json \
-    --oauthCallbackPath /auth/callback
+    --oauthCallbackPath /auth/callback \
+    --oauthScope=openid
 ```
 
 ## Integration with KeyCloak


### PR DESCRIPTION
Update the OAuth authentication example to include the required `--oauthScope` argument.

Note that the Keycloak example repo may also need to be revised.